### PR TITLE
minor tweaks to resource names

### DIFF
--- a/stack/certificates.py
+++ b/stack/certificates.py
@@ -10,7 +10,7 @@ from .domain import domain_name
 
 application = Ref(template.add_resource(
     Certificate(
-        'application',
+        'Certificate',
         DomainName=domain_name,
         DomainValidationOptions=[
             DomainValidationOption(

--- a/stack/repository.py
+++ b/stack/repository.py
@@ -1,6 +1,7 @@
 from troposphere import (
     AWS_ACCOUNT_ID,
     AWS_REGION,
+    AWS_STACK_NAME,
     Join,
     Ref,
     Output,
@@ -21,7 +22,7 @@ from .template import template
 repository = Repository(
     "ApplicationRepository",
     template=template,
-    RepositoryName="application",
+    RepositoryName=Ref(AWS_STACK_NAME),
     # Allow all account users to manage images.
     RepositoryPolicyText=Policy(
         Version="2008-10-17",


### PR DESCRIPTION
- The SSL certificate's logical name should be 'Certificate' (or something similar) rather than 'application'
- Similarly, the AWS CloudFormation stack name can be used for the ECR repository name, in case multiple stacks are created on the same account