### PR TITLE
fix LaunchConfiguration so instances register with the right cluster

### DIFF
--- a/stack/cluster.py
+++ b/stack/cluster.py
@@ -342,7 +342,7 @@ container_instance_configuration = autoscaling.LaunchConfiguration(
                     "/etc/cfn/cfn-hup.conf": cloudformation.InitFile(
                         content=Join("", [
                             "[main]\n",
-                            "template=",
+                            "stack=",
                             Ref(AWS_STACK_ID),
                             "\n",
                             "region=",
@@ -353,7 +353,7 @@ container_instance_configuration = autoscaling.LaunchConfiguration(
                         owner="root",
                         group="root",
                     ),
-                    "/etc/cfn/hooks.d/cfn-auto-reload.conf":
+                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf":
                     cloudformation.InitFile(
                         content=Join("", [
                             "[cfn-auto-reloader-hook]\n",
@@ -362,7 +362,7 @@ container_instance_configuration = autoscaling.LaunchConfiguration(
                             % container_instance_configuration_name,
                             "Metadata.AWS::CloudFormation::Init\n",
                             "action=/opt/aws/bin/cfn-init -v ",
-                            "         --stack",
+                            "         --stack ",
                             Ref(AWS_STACK_NAME),
                             "         --resource %s"
                             % container_instance_configuration_name,
@@ -395,9 +395,12 @@ container_instance_configuration = autoscaling.LaunchConfiguration(
     UserData=Base64(Join('', [
         "#!/bin/bash -xe\n",
         "yum install -y aws-cfn-bootstrap\n",
-
         "/opt/aws/bin/cfn-init -v ",
-        "         --stack", Ref(AWS_STACK_NAME),
+        "         --stack ", Ref(AWS_STACK_NAME),
+        "         --resource %s " % container_instance_configuration_name,
+        "         --region ", Ref(AWS_REGION), "\n",
+        "/opt/aws/bin/cfn-signal -e $? ",
+        "         --stack ", Ref(AWS_STACK_NAME),
         "         --resource %s " % container_instance_configuration_name,
         "         --region ", Ref(AWS_REGION), "\n",
     ])),


### PR DESCRIPTION
I found that with current master instances were not getting registered properly with the correct cluster (they were using the default cluster instead).

I troubleshot this by comparing the output of the troposphere code to the current CloudFormation ECS example code here: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-ecs.html

This resulted in the edits in this PR. Instances now register successfully with the correct cluster.