### PR TITLE
update AMIs to amzn-ami-2016.09.b-amazon-ecs-optimized

### DIFF
--- a/stack/cluster.py
+++ b/stack/cluster.py
@@ -139,9 +139,15 @@ secret_key = Ref(template.add_parameter(Parameter(
 
 
 template.add_mapping("ECSRegionMap", {
-    "eu-west-1": {"AMI": "ami-4e6ffe3d"},
-    "us-east-1": {"AMI": "ami-8f7687e2"},
-    "us-west-2": {"AMI": "ami-84b44de4"},
+    "us-east-1": {"AMI": "ami-eca289fb"},
+    "us-east-2": {"AMI": "ami-446f3521"},
+    "us-west-1": {"AMI": "ami-9fadf8ff"},
+    "us-west-2": {"AMI": "ami-7abc111a"},
+    "eu-west-1": {"AMI": "ami-a1491ad2"},
+    "eu-central-1": {"AMI": "ami-54f5303b"},
+    "ap-northeast-1": {"AMI": "ami-9cd57ffd"},
+    "ap-southeast-1": {"AMI": "ami-a900a3ca"},
+    "ap-southeast-2": {"AMI": "ami-5781be34"},
 })
 
 


### PR DESCRIPTION
With the current AMIs, I get a warning about an out of date agent after creating the stack. These new AMIs from http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html fix the issue. I also added the missing regions.